### PR TITLE
Forward error Display and causes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,8 +46,14 @@ impl fmt::Display for AsyncError {
     }
 }
 
-// TODO: Forward causes
-impl StdError for AsyncError {}
+impl StdError for AsyncError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        match *self {
+            AsyncError::Checkout(ref err) => Some(err),
+            AsyncError::Error(ref err) => Some(err),
+        }
+    }
+}
 
 #[async_trait]
 pub trait AsyncConnection<Conn>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,10 +37,12 @@ impl<T> OptionalExtension<T> for AsyncResult<T> {
     }
 }
 
-// TODO: Forward displays
 impl fmt::Display for AsyncError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self)
+        match *self {
+            AsyncError::Checkout(ref err) => err.fmt(f),
+            AsyncError::Error(ref err) => err.fmt(f),
+        }
     }
 }
 


### PR DESCRIPTION
### Changed

* Forward `Display` implementations for `AsyncError`.
* Forward `std::error::Error::source()` for `AsyncError`.

@mehcode This pull request eliminates two TODOs in the codebase and ensures the errors are displayed correctly when printed.