### PR TITLE
Add AsyncSimpleConnection trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ where
 }
 
 #[async_trait]
-pub trait AsyncConnection<Conn>
+pub trait AsyncConnection<Conn>: AsyncSimpleConnection<Conn>
 where
     Conn: 'static + Connection,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,10 +194,7 @@ where
         asc.run(|conn| self.get_result(&*conn)).await
     }
 
-    async fn get_results_async<U>(
-        self,
-        asc: &Pool<ConnectionManager<Conn>>,
-    ) -> AsyncResult<Vec<U>>
+    async fn get_results_async<U>(self, asc: &Pool<ConnectionManager<Conn>>) -> AsyncResult<Vec<U>>
     where
         U: 'static + Send,
         Self: LoadQuery<Conn, U>,


### PR DESCRIPTION
### Added

* Add `AsyncSimpleConnection` trait, mirroring the [`SimpleConnection`](https://docs.diesel.rs/diesel/connection/trait.SimpleConnection.html) trait provided by Diesel.

This additional trait is helpful for batch executing arbitrary SQL statements that don't produce any final output, namely backend-specific pragmas.

With that said, I wonder if this trait could be done away with entirely, in favor of adding the `batch_execute_async()` method to the existing `AsyncConnection` trait instead? The `diesel::connection::Connection` trait has `diesel::connection::SimpleConnection` as a trait bound, after all, so you cannot have one without the other. If we go this route, I would be happy to close this PR and open a new one that simply adds the method to `AsyncConnection`.

CC @mehcode 

Sorry to be bugging you with so many pull requests lately. 😅