### PR TITLE
Use task::block_in_place

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,13 +9,14 @@ license = "MIT/Apache-2.0"
 categories = ["asynchronous", "database"]
 
 [dependencies]
-async-trait = "0.1.21"
-diesel = { version = "1.4.3", features = [ "r2d2" ] }
-futures = "0.3.1"
-r2d2 = "0.8.7"
-tokio = { version = "0.2.4", features = [ "blocking" ] }
+async-trait = "0.1.30"
+diesel = { version = "1.4.4", features = [ "r2d2" ] }
+futures = "0.3.4"
+r2d2 = "0.8.8"
+tokio = { version = "0.2.17", features = [ "rt-threaded", "blocking" ] }
 
 [dev-dependencies]
-diesel = { version = "1.4.3", features = [ "postgres", "uuidv07" ] }
-uuid = { version = "0.7.4", features = [ "v4" ] }
-tokio = { version = "0.2.4", default-features = false, features = [ "full" ] }
+diesel = { version = "1.4.4", features = [ "postgres", "uuidv07" ] }
+uuid = { version = "0.8.1", features = [ "v4" ] }
+tokio = { version = "0.2.17", default-features = false, features = [ "full" ] }
+


### PR DESCRIPTION
Use `task::block_in_place` with allows a number of `'static` lifetimes
to be removed.

Fixes #9.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>