### PR TITLE
Use task::block_in_place

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: ci
+on:
+    pull_request:
+    push:
+        branches:
+            - master
+
+jobs:
+    check:
+        name: Check
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v1
+            - uses: actions-rs/toolchain@v1
+              with:
+                  toolchain: stable
+                  override: true
+            - uses: actions-rs/cargo@v1
+              with:
+                  command: check
+
+    rustfmt:
+        name: Format
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v1
+            - uses: actions-rs/toolchain@v1
+              with:
+                  toolchain: stable
+                  override: true
+            - run: rustup component add rustfmt
+            - uses: actions-rs/cargo@v1
+              with:
+                  command: fmt
+                  args: --all -- --check
+
+    test:
+        name: Test Suite
+        runs-on: ubuntu-latest
+        services:
+            postgres:
+                image: postgres
+                env:
+                    POSTGRES_USER: postgres
+                    POSTGRES_PASSWORD: postgres
+                    POSTGRES_DB: postgres
+                    POSTGRES_HOST_AUTH_METHOD: trust
+                ports:
+                    - 5432:5432
+                # needed because the postgres container does not provide a healthcheck
+                options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+        steps:
+            - name: Checkout sources
+              uses: actions/checkout@v1
+
+            - name: Install PostgreSQL client
+              run: sudo apt-get -yqq install libpq-dev
+
+            - name: Install toolchain
+              uses: actions-rs/toolchain@v1
+              with:
+                  toolchain: stable
+                  override: true
+
+            - name: Run cargo test
+              uses: actions-rs/cargo@v1
+              with:
+                  command: test
+              env:
+                  POSTGRES_HOST: localhost
+                  POSTGRES_PORT: ${{ job.services.postgres.ports[5432] }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,13 +9,13 @@ license = "MIT/Apache-2.0"
 categories = ["asynchronous", "database"]
 
 [dependencies]
-async-trait = "0.1.21"
-diesel = { version = "1.4.3", features = [ "r2d2" ] }
-futures = "0.3.1"
-r2d2 = "0.8.7"
-tokio = { version = "0.2.4", features = [ "blocking" ] }
+async-trait = "0.1.31"
+diesel = { version = "1.4.4", default-features = false, features = [ "r2d2" ] }
+futures = { version = "0.3.5", default-features = false }
+r2d2 = "0.8.8"
+tokio = { version = ">=0.2.21", default-features = false, features = [ "blocking", "rt-threaded" ] }
 
 [dev-dependencies]
-diesel = { version = "1.4.3", features = [ "postgres", "uuidv07" ] }
-uuid = { version = "0.7.4", features = [ "v4" ] }
-tokio = { version = "0.2.4", default-features = false, features = [ "full" ] }
+diesel = { version = "1.4.4", default-features = false, features = [ "postgres", "uuidv07" ] }
+uuid = { version = "0.8.1", features = [ "v4" ] }
+tokio = { version = ">=0.2.21", default-features = false, features = [ "full" ] }

--- a/tests/create_users.sql
+++ b/tests/create_users.sql
@@ -1,0 +1,1 @@
+CREATE table users (id uuid);

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,0 +1,43 @@
+#[macro_use]
+extern crate diesel;
+
+use diesel::{
+    prelude::*,
+    r2d2::{ConnectionManager, Pool},
+    sql_query,
+};
+use std::error::Error;
+use tokio_diesel::*;
+use uuid::Uuid;
+
+// Schema
+table! {
+    users (id) {
+        id -> Uuid,
+    }
+}
+
+#[tokio::test(threaded_scheduler)]
+async fn test_db_ops() -> Result<(), Box<dyn Error>> {
+    let manager = ConnectionManager::<PgConnection>::new("postgres://postgres@localhost");
+    let pool = Pool::builder().build(manager)?;
+
+    let _ = sql_query(include_str!("./create_users.sql"))
+        .execute_async(&pool)
+        .await;
+
+    // Add
+    println!("add a user");
+    diesel::insert_into(users::table)
+        .values(users::id.eq(Uuid::new_v4()))
+        .execute_async(&pool)
+        .await?;
+
+    // Count
+    let num_users: i64 = users::table.count().get_result_async(&pool).await?;
+    println!("now there are {:?} users", num_users);
+
+    assert!(num_users > 0);
+
+    Ok(())
+}


### PR DESCRIPTION
Use `task::block_in_place` with allows a number of `'static` lifetimes
to be removed.

This now works outside a task spawn due to
https://github.com/tokio-rs/tokio/pull/2410 with the restriction that a
threaded runtime is used.

I've also added in github actions to ensure this change works (and
continues to) :) .

Fixes #9.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>