### PR TITLE
bugfix - renamed OptionalExtension trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,11 +24,11 @@ pub enum AsyncError {
     Error(diesel::result::Error),
 }
 
-pub trait OptionalExtension<T> {
+pub trait OptionalExtensionForAsyncResult<T> {
     fn optional(self) -> Result<Option<T>, AsyncError>;
 }
 
-impl<T> OptionalExtension<T> for AsyncResult<T> {
+impl<T> OptionalExtensionForAsyncResult<T> for AsyncResult<T> {
     fn optional(self) -> Result<Option<T>, AsyncError> {
         match self {
             Ok(value) => Ok(Some(value)),


### PR DESCRIPTION
Renamed `OptionalExtension` trait, because it was hidden by the same trait in `diesel::prelude::*`.
For this reason, this didn't compile
```rust
use diesel::prelude::*;
use tokio_diesel::*;
```
In order to compile it you needed to swap order of use declarations, or explicitly add `tokio_diesel::OptionalExtension`;
So in order to solve this issue I basically renamed this trait, and it solved the problem ;)
I think the same should be done in [async-diesel](https://github.com/mehcode/async-diesel) as well.