### PR TITLE
Switch to task::spawn_blocking.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,10 +73,12 @@ where
     async fn batch_execute_async(&self, query: &str) -> AsyncResult<()> {
         let self_ = self.clone();
         let query = query.to_string();
-        task::block_in_place(move || {
+        task::spawn_blocking(move || {
             let conn = self_.get().map_err(AsyncError::Checkout)?;
             conn.batch_execute(&query).map_err(AsyncError::Error)
         })
+        .await
+        .unwrap()
     }
 }
 
@@ -87,13 +89,13 @@ where
 {
     async fn run<R, Func>(&self, f: Func) -> AsyncResult<R>
     where
-        R: Send,
-        Func: FnOnce(&Conn) -> QueryResult<R> + Send;
+        R: Send + 'static,
+        Func: FnOnce(&Conn) -> QueryResult<R> + Send + 'static;
 
     async fn transaction<R, Func>(&self, f: Func) -> AsyncResult<R>
     where
-        R: Send,
-        Func: FnOnce(&Conn) -> QueryResult<R> + Send;
+        R: Send + 'static,
+        Func: FnOnce(&Conn) -> QueryResult<R> + Send + 'static;
 }
 
 #[async_trait]
@@ -104,27 +106,31 @@ where
     #[inline]
     async fn run<R, Func>(&self, f: Func) -> AsyncResult<R>
     where
-        R: Send,
-        Func: FnOnce(&Conn) -> QueryResult<R> + Send,
+        R: Send + 'static,
+        Func: FnOnce(&Conn) -> QueryResult<R> + Send + 'static,
     {
         let self_ = self.clone();
-        task::block_in_place(move || {
+        task::spawn_blocking(move || {
             let conn = self_.get().map_err(AsyncError::Checkout)?;
             f(&*conn).map_err(AsyncError::Error)
         })
+        .await
+        .unwrap() // Propagate panics
     }
 
     #[inline]
     async fn transaction<R, Func>(&self, f: Func) -> AsyncResult<R>
     where
-        R: Send,
-        Func: FnOnce(&Conn) -> QueryResult<R> + Send,
+        R: Send + 'static,
+        Func: FnOnce(&Conn) -> QueryResult<R> + Send + 'static,
     {
         let self_ = self.clone();
-        task::block_in_place(move || {
+        task::spawn_blocking(move || {
             let conn = self_.get().map_err(AsyncError::Checkout)?;
             conn.transaction(|| f(&*conn)).map_err(AsyncError::Error)
         })
+        .await
+        .unwrap() // Propagate panics
     }
 }
 
@@ -137,24 +143,24 @@ where
     where
         Self: ExecuteDsl<Conn>;
 
-    async fn load_async<U>(self, asc: &AsyncConn) -> AsyncResult<Vec<U>>
+    async fn load_async<'a, U>(self, asc: &AsyncConn) -> AsyncResult<Vec<U>>
     where
-        U: Send,
+        U: Send + 'static,
         Self: LoadQuery<Conn, U>;
 
     async fn get_result_async<U>(self, asc: &AsyncConn) -> AsyncResult<U>
     where
-        U: Send,
+        U: Send + 'static,
         Self: LoadQuery<Conn, U>;
 
     async fn get_results_async<U>(self, asc: &AsyncConn) -> AsyncResult<Vec<U>>
     where
-        U: Send,
+        U: Send + 'static,
         Self: LoadQuery<Conn, U>;
 
     async fn first_async<U>(self, asc: &AsyncConn) -> AsyncResult<U>
     where
-        U: Send,
+        U: Send + 'static,
         Self: LimitDsl,
         Limit<Self>: LoadQuery<Conn, U>;
 }
@@ -162,7 +168,7 @@ where
 #[async_trait]
 impl<T, Conn> AsyncRunQueryDsl<Conn, Pool<ConnectionManager<Conn>>> for T
 where
-    T: Send + RunQueryDsl<Conn>,
+    T: Send + RunQueryDsl<Conn> + 'static,
     Conn: 'static + Connection,
 {
     async fn execute_async(self, asc: &Pool<ConnectionManager<Conn>>) -> AsyncResult<usize>
@@ -172,9 +178,9 @@ where
         asc.run(|conn| self.execute(&*conn)).await
     }
 
-    async fn load_async<U>(self, asc: &Pool<ConnectionManager<Conn>>) -> AsyncResult<Vec<U>>
+    async fn load_async<'a, U>(self, asc: &Pool<ConnectionManager<Conn>>) -> AsyncResult<Vec<U>>
     where
-        U: Send,
+        U: Send + 'static,
         Self: LoadQuery<Conn, U>,
     {
         asc.run(|conn| self.load(&*conn)).await
@@ -182,7 +188,7 @@ where
 
     async fn get_result_async<U>(self, asc: &Pool<ConnectionManager<Conn>>) -> AsyncResult<U>
     where
-        U: Send,
+        U: Send + 'static,
         Self: LoadQuery<Conn, U>,
     {
         asc.run(|conn| self.get_result(&*conn)).await
@@ -190,7 +196,7 @@ where
 
     async fn get_results_async<U>(self, asc: &Pool<ConnectionManager<Conn>>) -> AsyncResult<Vec<U>>
     where
-        U: Send,
+        U: Send + 'static,
         Self: LoadQuery<Conn, U>,
     {
         asc.run(|conn| self.get_results(&*conn)).await
@@ -198,7 +204,7 @@ where
 
     async fn first_async<U>(self, asc: &Pool<ConnectionManager<Conn>>) -> AsyncResult<U>
     where
-        U: Send,
+        U: Send + 'static,
         Self: LimitDsl,
         Limit<Self>: LoadQuery<Conn, U>,
     {


### PR DESCRIPTION
Instead of blocking the current thread, we perform this I/O to an I/O thread.